### PR TITLE
travis: cache conan packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,10 @@ language: cpp
 dist: xenial
 sudo: false
 
+cache:
+  directories:
+    - $HOME/.conan
+
 stages:
   - clang-format-check
   - build

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ sudo: false
 cache:
   directories:
     - $HOME/.conan
+    - $HOME/.cache/pip
 
 stages:
   - clang-format-check


### PR DESCRIPTION
Some dependencies may require building from source, which can take a long time.