### PR TITLE
telemetry: add missing PiHiPri file

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -16,7 +16,8 @@ add_library(wiringPi
   wiringPi/wiringPi.c
   wiringPi/wiringPiI2C.c
   wiringPi/softPwm.c
-  wiringPi/softTone.c)
+  wiringPi/softTone.c
+  wiringPi/PiHiPri.c)
 
 target_include_directories(wiringPi PRIVATE ../include)
 

--- a/lib/wiringPi/PiHiPri.c
+++ b/lib/wiringPi/PiHiPri.c
@@ -1,0 +1,50 @@
+/*
+ * piHiPri:
+ *	Simple way to get your program running at high priority
+ *	with realtime schedulling.
+ *
+ *	Copyright (c) 2012 Gordon Henderson
+ ***********************************************************************
+ * This file is part of wiringPi:
+ *	https://projects.drogon.net/raspberry-pi/wiringpi/
+ *
+ *    wiringPi is free software: you can redistribute it and/or modify
+ *    it under the terms of the GNU Lesser General Public License as
+ *    published by the Free Software Foundation, either version 3 of the
+ *    License, or (at your option) any later version.
+ *
+ *    wiringPi is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU Lesser General Public License for more details.
+ *q
+ *    You should have received a copy of the GNU Lesser General Public
+ *    License along with wiringPi.
+ *    If not, see <http://www.gnu.org/licenses/>.
+ ***********************************************************************
+ */
+
+#include <sched.h>
+#include <string.h>
+
+#include "wiringPi/wiringPi.h"
+
+/*
+ * piHiPri:
+ *	Attempt to set a high priority schedulling for the running program
+ *********************************************************************************
+ */
+
+int piHiPri(const int pri)
+{
+  struct sched_param sched;
+
+  memset(&sched, 0, sizeof(sched));
+
+  if (pri > sched_get_priority_max(SCHED_RR))
+    sched.sched_priority = sched_get_priority_max(SCHED_RR);
+  else
+    sched.sched_priority = pri;
+
+  return sched_setscheduler(0, SCHED_RR, &sched);
+}


### PR DESCRIPTION
This file was missing, preventing the correct linking of the library into other executables.